### PR TITLE
Replace orderId in returnUrl with publicReference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ application.properties
 .idea/
 build/
 src/main/resources/templates/fragments/product/
+config/oidc-client-registration.json

--- a/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
@@ -54,7 +54,7 @@ public class MolliePaymentService implements PaymentService {
         amount += 0.29;
 
         CreatePayment payment = new CreatePayment(method, amount, "W.I.S.V. 'Christiaan Huygens' Payments",
-                returnUrl + "?order=" + order.getId(), metadata);
+                returnUrl + "?reference=" + order.getPublicReference(), metadata);
 
         //First try is for IOExceptions coming from the Mollie Client.
         try {


### PR DESCRIPTION
The orderId is not what you want in the returnUrl for the user. We only want to check on the publicReference.