### PR TITLE
Development command for gradle to omit running IntelliJ

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,3 +72,12 @@ dependencies {
     testCompile 'io.rest-assured:rest-assured:3.0.1'
     testCompile('org.springframework.boot:spring-boot-starter-test')
 }
+
+task dev(type: org.springframework.boot.gradle.run.BootRunTask) {
+    group = 'Application'
+    doFirst() {
+        main = project.mainClassName
+        classpath = sourceSets.main.runtimeClasspath
+        systemProperty 'spring.profiles.active', 'dev'
+    }
+}


### PR DESCRIPTION
For front-end development, being able to run payments without starting IntelliJ would be great! The task can be started with: `./gradlew dev`.