### PR TITLE
Add returnUrl specification

### DIFF
--- a/src/main/java/ch/wisv/payments/model/OrderRequest.java
+++ b/src/main/java/ch/wisv/payments/model/OrderRequest.java
@@ -2,7 +2,6 @@ package ch.wisv.payments.model;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.NotEmpty;
-import org.hibernate.validator.constraints.URL;
 
 import java.util.List;
 
@@ -17,6 +16,6 @@ public class OrderRequest {
     @NotEmpty
     String email;
 
-    @URL
+    @NotEmpty
     String returnUrl;
 }

--- a/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
@@ -43,8 +43,14 @@ public class MolliePaymentService implements PaymentService {
 
         String method = "ideal";
 
+        // If the String {reference} is present in the url, this is the place to put the public reference
         if (order.getReturnURL() != null) {
             returnUrl = order.getReturnURL();
+            if (!returnUrl.contains("{reference}")) {
+                returnUrl = returnUrl + "?reference=" + order.getPublicReference();
+            } else {
+                returnUrl = returnUrl.replace("{reference}", order.getPublicReference());
+            }
         }
 
         double amount = order.getProducts().stream()
@@ -54,7 +60,7 @@ public class MolliePaymentService implements PaymentService {
         amount += 0.29;
 
         CreatePayment payment = new CreatePayment(method, amount, "W.I.S.V. 'Christiaan Huygens' Payments",
-                returnUrl + "?reference=" + order.getPublicReference(), metadata);
+                returnUrl, metadata);
 
         //First try is for IOExceptions coming from the Mollie Client.
         try {


### PR DESCRIPTION
This gives the user more freedom in specifying the kind of returnUrl. Some applications should not have the query-parameters at the end of the url, for instance hash-routing, or the users would want to have a bit more freedom specifying the format of the url.