### PR TITLE
Fix CSS & JS references

### DIFF
--- a/config/application.properties.sample
+++ b/config/application.properties.sample
@@ -45,3 +45,5 @@ payments.admin.groups=chbeheer,bestuur,hoothub
 
 payments.admin.username=admin
 payments.admin.password=password
+
+server.context-path=/payments/

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -9,13 +9,12 @@
     <title>About CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
-    <link th:href="@{css/cover.css}" rel="stylesheet">
+    <link th:href="@{/css/cover.css}" rel="stylesheet">
 
 </head>
 

--- a/src/main/resources/templates/committees.html
+++ b/src/main/resources/templates/committees.html
@@ -7,17 +7,16 @@
     <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
     <meta name="description" content="">
     <meta name="author" content="">
-    <link rel="icon" href="../../favicon.ico">
 
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
-    <link href="/css/dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.css"/>
 
@@ -96,11 +95,11 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
 <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.js"></script>
-<script src="webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
 <script>
     $(document).ready(function () {
         $('#committeeTable').DataTable();
     });
 </script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/dashboard.html
+++ b/src/main/resources/templates/dashboard.html
@@ -12,12 +12,12 @@
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link th:href="@{webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
-    <link th:href="@{css/dashboard.css}" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -77,6 +77,6 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
-<script src="webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/edit.html
+++ b/src/main/resources/templates/edit.html
@@ -12,12 +12,12 @@
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link th:href="@{webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
-    <link th:href="@{css/dashboard.css}" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.css"/>
 
@@ -120,6 +120,6 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
-<script src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/fragments/footer.html
+++ b/src/main/resources/templates/fragments/footer.html
@@ -11,10 +11,10 @@
     <title>Dashboard Template for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="../dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -11,10 +11,10 @@
     <title>Dashboard Template for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="/dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -41,9 +41,9 @@
                 <form id="logoutForm" th:action="@{/logout}" method="post"></form>
 
                 <ul class="nav navbar-nav navbar-right">
-                    <li><a href="/dashboard">Dashboard</a></li>
-                    <li><a href="#">Settings</a></li>
-                    <li><a href="#">Help</a></li>
+                    <li><a th:href="@{/dashboard}">Dashboard</a></li>
+                    <!--<li><a href="#">Settings</a></li>-->
+                    <!--<li><a href="#">Help</a></li>-->
                     <li>
                         <a href="#" onclick="document.getElementById('logoutForm').submit();">Logout</a>
                     </li>

--- a/src/main/resources/templates/fragments/messages.html
+++ b/src/main/resources/templates/fragments/messages.html
@@ -11,10 +11,10 @@
     <title>Dashboard Template for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="/dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>

--- a/src/main/resources/templates/fragments/sidebar.html
+++ b/src/main/resources/templates/fragments/sidebar.html
@@ -11,10 +11,10 @@
     <title>Dashboard Template for Bootstrap</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
 
     <!-- Custom styles for this template -->
-    <link href="../dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!--[if lt IE 9]>
@@ -29,13 +29,14 @@
         <div th:fragment="sidebar">
             <div class="col-sm-3 col-md-2 sidebar">
                 <ul class="nav nav-sidebar">
-                    <li th:classappend="${#httpServletRequest.getRequestURI() == '/dashboard' ? 'active':''}"><a th:href="@{/dashboard}">Overview
+                    <li th:classappend="${#httpServletRequest.getRequestURI().contains('/dashboard') ? 'active':''}">
+                        <a th:href="@{/dashboard}">Overview
                         <span class="sr-only">(current)</span></a></li>
-                    <li th:classappend="${#httpServletRequest.getRequestURI() == '/committees' ? 'active':''}"><a
+                    <li th:classappend="${#httpServletRequest.getRequestURI().contains('/committees') ? 'active':''}"><a
                             th:href="@{/committees}">Committees</a></li>
                     <li th:classappend="${#httpServletRequest.getRequestURI().contains('/products') ? 'active':''}"><a
                             th:href="@{/products}" href="#">Products</a></li>
-                    <li th:classappend="${#httpServletRequest.getRequestURI() == '/orders' ? 'active':''}"><a
+                    <li th:classappend="${#httpServletRequest.getRequestURI().contains('/orders') ? 'active':''}"><a
                             th:href="@{/orders}">Orders</a></li>
                 </ul>
             </div>

--- a/src/main/resources/templates/login.html
+++ b/src/main/resources/templates/login.html
@@ -12,7 +12,7 @@
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
+    <link th:href="@{webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
     <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
@@ -51,6 +51,6 @@
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
-<script src="/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/orders.html
+++ b/src/main/resources/templates/orders.html
@@ -12,12 +12,12 @@
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
-    <link href="/css/dashboard.css" rel="stylesheet">
+    <link th:href="@{/css/dashboard.css}" rel="stylesheet">
 
     <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.css"/>
 
@@ -93,11 +93,11 @@
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
 <script>window.jQuery || document.write('<script src="../../assets/js/vendor/jquery.min.js"><\/script>')</script>
 <script type="text/javascript" src="https://cdn.datatables.net/v/bs/dt-1.10.12/datatables.min.js"></script>
-<script src="webjars/bootstrap/3.3.7-1/js/bootstrap.min.js"></script>
 <script>
     $(document).ready(function () {
         $('#ordersTable').DataTable();
     });
 </script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -12,8 +12,8 @@
     <title>CH Payments</title>
 
     <!-- Bootstrap core CSS -->
-    <link href="webjars/bootstrap/3.3.7-1/css/bootstrap.min.css" rel="stylesheet">
-    <link th:href="@{webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
+    <link th:href="@{/webjars/bootstrap/3.3.7-1/css/bootstrap.min.css}" rel="stylesheet">
+    <link th:href="@{/webjars/wisvch-bootstrap-theme/0.0.3/dist/css/bootstrap.min.css}"
           rel="stylesheet" media="screen"/>
 
     <!-- Custom styles for this template -->
@@ -219,12 +219,12 @@
                     </td>
                     <td>
                         <!--<div class="btn-group" role="group" aria-label="...">-->
-                            <!--<button type="button" class="btn btn-info" aria-label="Edit">-->
-                                <!--<span class="glyphicon glyphicon-edit" aria-hidden="true"></span>-->
-                            <!--</button>-->
-                            <!--<button type="button" class="btn btn-danger" aria-label="Remove">-->
-                                <!--<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>-->
-                            <!--</button>-->
+                        <!--<button type="button" class="btn btn-info" aria-label="Edit">-->
+                        <!--<span class="glyphicon glyphicon-edit" aria-hidden="true"></span>-->
+                        <!--</button>-->
+                        <!--<button type="button" class="btn btn-danger" aria-label="Remove">-->
+                        <!--<span class="glyphicon glyphicon-remove" aria-hidden="true"></span>-->
+                        <!--</button>-->
                         <!--</div>-->
                     </td>
                 </tr>
@@ -244,5 +244,6 @@
         $('#productsTable').DataTable();
     });
 </script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
Some CSS and JS files were linked relatively. All references are replaced with thymeleaf references, which figures it out regardless of root path. 

Added context path to sample properties for a production-like environment