### PR TITLE
Fix webhook lookup

### DIFF
--- a/src/main/java/ch/wisv/payments/admin/OrderController.java
+++ b/src/main/java/ch/wisv/payments/admin/OrderController.java
@@ -35,7 +35,7 @@ public class OrderController {
     @PostMapping("/update/{orderReference}")
     String updateOrder(Model model, @PathVariable String orderReference, RedirectAttributes redirectAttributes) {
         try {
-            Order order = paymentService.updateStatus(orderReference);
+            Order order = paymentService.updateStatusByPublicReference(orderReference);
             redirectAttributes.addFlashAttribute("message", "Order " + order.getId() + " successfully updated!");
         } catch (RuntimeException e) {
             redirectAttributes.addFlashAttribute("error", e.getMessage());

--- a/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
@@ -90,7 +90,7 @@ public class MolliePaymentService implements PaymentService {
 
     @Override
     public Order updateStatusByPublicReference(String publicOrderReference) {
-        Order order = orderRepository.findByProviderReference(publicOrderReference)
+        Order order = orderRepository.findByPublicReference(publicOrderReference)
                 .orElseThrow(() -> new RuntimeException("Order with publicReference " + publicOrderReference + " not found"));
         return updateOrder(order);
     }

--- a/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
@@ -89,10 +89,20 @@ public class MolliePaymentService implements PaymentService {
     }
 
     @Override
-    public Order updateStatus(String orderReference) {
-        Order order = orderRepository.findByProviderReference(orderReference)
-                .orElseThrow(() -> new RuntimeException("Order with providerReference " + orderReference + " not found"));
+    public Order updateStatusByPublicReference(String publicOrderReference) {
+        Order order = orderRepository.findByProviderReference(publicOrderReference)
+                .orElseThrow(() -> new RuntimeException("Order with publicReference " + publicOrderReference + " not found"));
+        return updateOrder(order);
+    }
 
+    @Override
+    public Order updateStatusByProviderReference(String providerOrderReference) {
+        Order order = orderRepository.findByProviderReference(providerOrderReference)
+                .orElseThrow(() -> new RuntimeException("Order with providerReference " + providerOrderReference + " not found"));
+        return updateOrder(order);
+    }
+
+    private Order updateOrder(Order order) {
         // This try is for the Mollie API internal HttpClient
         try {
             // Request a payment from Mollie

--- a/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/MolliePaymentService.java
@@ -90,7 +90,7 @@ public class MolliePaymentService implements PaymentService {
 
     @Override
     public Order updateStatus(String orderReference) {
-        Order order = orderRepository.findByPublicReference(orderReference)
+        Order order = orderRepository.findByProviderReference(orderReference)
                 .orElseThrow(() -> new RuntimeException("Order with providerReference " + orderReference + " not found"));
 
         // This try is for the Mollie API internal HttpClient
@@ -116,7 +116,7 @@ public class MolliePaymentService implements PaymentService {
                         break;
                     }
                     case "paid": {
-                        if(!order.getStatus().equals(OrderStatus.PAID)){
+                        if (!order.getStatus().equals(OrderStatus.PAID)) {
                             mailService.sendOrderConfirmation(order);
                         }
                         order.setStatus(OrderStatus.PAID);

--- a/src/main/java/ch/wisv/payments/rest/OrderRestController.java
+++ b/src/main/java/ch/wisv/payments/rest/OrderRestController.java
@@ -40,9 +40,15 @@ public class OrderRestController {
         return new ResponseEntity<>(new OrderResponse(order), HttpStatus.OK);
     }
 
+    /**
+     * This endpoint is for the paymentprovider. Webhooks will arrive here.
+     *
+     * @param providerReference The provider Order Reference
+     * @return Status Message
+     */
     @RequestMapping(value = "/status", method = RequestMethod.POST)
-    public ResponseEntity<?> updateOrderStatus(@RequestParam(name = "id") String orderReference) {
-        paymentService.updateStatus(orderReference);
+    public ResponseEntity<?> updateOrderStatus(@RequestParam(name = "id") String providerReference) {
+        paymentService.updateStatusByProviderReference(providerReference);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 

--- a/src/main/java/ch/wisv/payments/rest/PaymentService.java
+++ b/src/main/java/ch/wisv/payments/rest/PaymentService.java
@@ -11,6 +11,8 @@ public interface PaymentService {
 
     OrderResponse registerOrder(Order order);
 
-    Order updateStatus(String orderReference);
+    Order updateStatusByPublicReference(String publicOrderReference);
+
+    Order updateStatusByProviderReference(String providerOrderReference);
 
 }

--- a/src/main/resources/templates/about.html
+++ b/src/main/resources/templates/about.html
@@ -76,9 +76,7 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.4.0/js/tether.min.js"
         integrity="sha384-DztdAPBWPRXSA/3eYEEUWrWCy7G5KFbe8fFjk5JAIxUYHKkDx6Qin1DkWx51bBrb"
         crossorigin="anonymous"></script>
-<script src="../../dist/js/bootstrap.min.js"></script>
-<!-- IE10 viewport hack for Surface/desktop Windows 8 bug -->
-<script src="../../assets/js/ie10-viewport-bug-workaround.js"></script>
+<script th:src="@{/webjars/bootstrap/3.3.7-1/js/bootstrap.min.js}"></script>
 </body>
 </html>
 

--- a/src/main/resources/templates/products.html
+++ b/src/main/resources/templates/products.html
@@ -209,8 +209,8 @@
                     <td th:text="${group.getCommittee().getName().getName()} + ' '+ ${group.getCommittee().getYear()}">
                         Row 1 Data 2
                     </td>
-                    <td th:text="${group.getGroupLimit()}">Group limit</td>
                     <td th:text="${group.getName()}">Row 1 Data 1</td>
+                    <td th:text="${group.getGroupLimit()}">Group limit</td>
                     <td th:text="${group.getDescription()}">Row 1 Data 3</td>
                     <td>
                         <ul th:each="product : ${group.getProducts()}">


### PR DESCRIPTION
We had a single method for order status updates. However, we used both public and provider references. Oops.

This PR separates lookup by ProviderReference and PublicReference