### PR TITLE
Use older travis image to use java8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 services:
 - docker
 language: java


### PR DESCRIPTION
Build was failing due to the distribution not supporting java8. Keeping an older build image fixes this.

#80 should be fixed since java8 is out of support, and spring boot 1 is eol.