### PR TITLE
Use default (Ubuntu Xenial) Travis CI worker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 sudo: required
-dist: trusty
 services:
 - docker
 language: java
-jdk: oraclejdk8
+jdk: openjdk8
 script:
 - "./gradlew clean build -PbuildNumber=$TRAVIS_BUILD_NUMBER --scan"
 - docker build --no-cache --pull -t wisvch/payments:$TRAVIS_BUILD_NUMBER .


### PR DESCRIPTION
Ubuntu Trusty has been out of support for almost a year, and Ubuntu
Xenial works fine when using `openjdk8` instead of `oraclejdk8`.